### PR TITLE
Create /var/crash after creating /var RAM disk. Fixes #9409

### DIFF
--- a/src/etc/rc.embedded
+++ b/src/etc/rc.embedded
@@ -44,4 +44,5 @@ mdmfs -S -M -s ${varsize} md /var
 
 # Ensure vi's recover directory is present
 /bin/mkdir -p /var/tmp/vi.recover/
+/bin/mkdir -p /var/crash/
 echo " done."


### PR DESCRIPTION
(cherry picked from commit b39d615394eabd2d19afef0936219c609ef602e3)

- [ ] Redmine Issue: https://redmine.pfsense.org/issues/NNNN
- [ ] Ready for review